### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - baobab
+      - /baobab
 
 volumes:
   baobab:


### PR DESCRIPTION
Made the baobab volume absolute

When I ran docker-compose on  I got this error

```
ERROR: for baobab_lims  Cannot start service baobab_lims: failed to create shim: OCI runtime create failed: invalid mount {Destination:baobab Type:bind Source:/var/lib/docker/volumes/f2f0b1b70754364ff9766d97c4ec9af37616d80a361628f41632743a827c097f/_data Options:[rbind]}: mount destination baobab not absolute: unknown
```

And an inspect of the resulting container shows that the dest

```
 "Mounts": [
            {
                "Type": "volume",
                "Name": "f2f0b1b70754364ff9766d97c4ec9af37616d80a361628f41632743a827c097f",
                "Source": "/var/lib/docker/volumes/f2f0b1b70754364ff9766d97c4ec9af37616d80a361628f41632743a827c097f/_data",
                "Destination": "baobab",
                "Driver": "local",
```

Doing some googling shows that the recommended solution was to change the destination to an absolute address and that worked flawlessly for me. There may have been some docker changes.
